### PR TITLE
Fix: カードのユーザー名取得処理でユーザー名が更新されないバグを直した

### DIFF
--- a/src/components/molecules/Card.tsx
+++ b/src/components/molecules/Card.tsx
@@ -1,0 +1,100 @@
+import React, { FC } from "react";
+import { StyleSheet, Text, Image, TouchableOpacity } from "react-native";
+import { Timestamp } from "@google-cloud/firestore";
+import { deviceWidth } from "../../utilities/dimensions";
+import { baseColor } from "../../styles/thema/colors";
+
+type PhotoDataList = {
+  photo_id: string;
+  uid: string;
+  create_time: Timestamp;
+  url: string;
+  latitude: number;
+  longitude: number;
+  photogenic_subject: string;
+};
+
+type Props = {
+  navigation: any;
+  data: PhotoDataList;
+  postUserName: string;
+};
+
+const CARD_HEIGHT = 220;
+const CARD_WIDTH = deviceWidth * 0.8;
+
+const Card: FC<Props> = ({ ...props }) => {
+  const { navigation, data, postUserName } = props;
+  return (
+    <TouchableOpacity
+      activeOpacity={0.85}
+      onPress={() => {
+        const photoDataList: PhotoDataList[] = [];
+        photoDataList.push(data);
+        navigation.navigate("post", {
+          imageData: {
+            photo_id: data.photo_id,
+            uid: data.uid,
+            create_time: data.create_time,
+            url: data.url,
+            latitude: data.latitude,
+            longitude: data.longitude,
+            photogenic_subject: data.photogenic_subject,
+          },
+        });
+      }}
+      key={data.photo_id}
+      style={styles.card}
+    >
+      <Image
+        source={{
+          uri: data.url,
+        }}
+        style={styles.cardImage}
+        resizeMode="cover"
+      />
+      <Text style={styles.cardText}>
+        {/* {data.photogenic_subject} */}
+        {postUserName}
+        <Text style={styles.cardTextSub}>さんの投稿</Text>
+      </Text>
+    </TouchableOpacity>
+  );
+};
+
+const styles = StyleSheet.create({
+  card: {
+    elevation: 2,
+    backgroundColor: baseColor.darkNavy,
+    borderColor: "rgba(170, 170, 170, 0.6)",
+    borderWidth: 0.5,
+    borderTopLeftRadius: 5,
+    borderTopRightRadius: 5,
+    borderBottomLeftRadius: 5,
+    borderBottomRightRadius: 5,
+    marginHorizontal: 10,
+    shadowColor: "#000",
+    shadowRadius: 5,
+    shadowOpacity: 0.3,
+    height: CARD_HEIGHT - 50,
+    width: CARD_WIDTH,
+    overflow: "hidden",
+  },
+  cardImage: {
+    flex: 3,
+    width: "100%",
+    height: "80%",
+    alignSelf: "center",
+  },
+  cardText: {
+    fontSize: 17,
+    color: baseColor.text,
+    fontWeight: "bold",
+    padding: 15,
+  },
+  cardTextSub: {
+    fontWeight: "normal",
+  },
+});
+
+export default Card;

--- a/src/components/organisms/Home.tsx
+++ b/src/components/organisms/Home.tsx
@@ -16,7 +16,6 @@ import MapViewType, { PROVIDER_GOOGLE, Marker } from "react-native-maps";
 import { useEffect } from "react";
 import { useTheme } from "@react-navigation/native";
 import { photoFireStore } from "../../firebase/photoFireStore";
-import { accountFireStore } from "../../firebase/accountFireStore";
 import { baseColor } from "../../styles/thema/colors";
 import * as Location from "expo-location";
 import MapView from "react-native-map-clustering";
@@ -26,6 +25,7 @@ import OriginMarker from "../atoms/OriginMarker";
 import { Region } from "../../entities/map";
 import geohash from "ngeohash";
 import { mapStyle } from "../../styles/map";
+import Card from "../../containers/molecules/Card";
 
 type PhotoDataList = {
   photo_id: string;
@@ -68,7 +68,6 @@ const Home: FC<Props> = ({ ...props }) => {
   const [photoDisplayFlag, setPhotoDisplayFlag] = useState(true);
   const [photoSnapFlag, setPhotoSnapFlag] = useState(false);
   const [photoPinFlag, setPhotoPinFlag] = useState(false);
-  const [postUserName, setPostUserName] = useState<string>("");
   const [photoSnapList, setPhotoSnapList] = useState<any>([]);
   const [mapState, setMapState] = useState({ isSet: false });
   const mapAnimation = useRef(new Animated.Value(0)).current;
@@ -81,18 +80,6 @@ const Home: FC<Props> = ({ ...props }) => {
 
   // photoSnapListが更新される度に実行
   useEffect(() => {
-    // ユーザー名の取得
-    const getUserName = (uid: string) => {
-      accountFireStore
-        .getUserName(uid)
-        .then((res: React.SetStateAction<string>) => {
-          setPostUserName(res);
-        })
-        .catch(() => {
-          setPostUserName("名無し");
-        });
-    };
-
     // photoSnap参考資料　https://www.youtube.com/watch?v=2vILzRmEqGI
     const fetch = async () => {
       mapAnimation.addListener(({ value }) => {
@@ -132,11 +119,8 @@ const Home: FC<Props> = ({ ...props }) => {
       });
     };
 
-    photoSnapList.map((data) => {
-      getUserName(data.uid);
-    });
     fetch();
-  }, [photoSnapList]);
+  }, [photoSnapList, region]);
 
   // 地図移動時付近1マイルの情報取得
   const handleRegionChange = async (region: Region) => {
@@ -340,41 +324,9 @@ const Home: FC<Props> = ({ ...props }) => {
               )}
             >
               {photoSnapList &&
-                photoSnapList.map((data) => {
+                photoSnapList.map((data, index) => {
                   return (
-                    <TouchableOpacity
-                      activeOpacity={0.85}
-                      onPress={() => {
-                        const photoDataList: PhotoDataList[] = [];
-                        photoDataList.push(data);
-                        navigation.navigate("post", {
-                          imageData: {
-                            photo_id: data.photo_id,
-                            uid: data.uid,
-                            create_time: data.create_time,
-                            url: data.url,
-                            latitude: data.latitude,
-                            longitude: data.longitude,
-                            photogenic_subject: data.photogenic_subject,
-                          },
-                        });
-                      }}
-                      key={data.photo_id}
-                      style={styles.card}
-                    >
-                      <Image
-                        source={{
-                          uri: data.url,
-                        }}
-                        style={styles.cardImage}
-                        resizeMode="cover"
-                      />
-                      <Text style={styles.cardText}>
-                        {/* {data.photogenic_subject} */}
-                        {postUserName}
-                        <Text style={styles.cardTextSub}>さんの投稿</Text>
-                      </Text>
-                    </TouchableOpacity>
+                    <Card key={index} navigation={navigation} data={data} />
                   );
                 })}
             </Animated.ScrollView>
@@ -406,38 +358,6 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     paddingVertical: 10,
-  },
-  card: {
-    elevation: 2,
-    backgroundColor: baseColor.darkNavy,
-    borderColor: "rgba(170, 170, 170, 0.6)",
-    borderWidth: 0.5,
-    borderTopLeftRadius: 5,
-    borderTopRightRadius: 5,
-    borderBottomLeftRadius: 5,
-    borderBottomRightRadius: 5,
-    marginHorizontal: 10,
-    shadowColor: "#000",
-    shadowRadius: 5,
-    shadowOpacity: 0.3,
-    height: CARD_HEIGHT - 50,
-    width: CARD_WIDTH,
-    overflow: "hidden",
-  },
-  cardImage: {
-    flex: 3,
-    width: "100%",
-    height: "80%",
-    alignSelf: "center",
-  },
-  cardText: {
-    fontSize: 17,
-    color: baseColor.text,
-    fontWeight: "bold",
-    padding: 15,
-  },
-  cardTextSub: {
-    fontWeight: "normal",
   },
 });
 export default Home;

--- a/src/containers/molecules/Card.tsx
+++ b/src/containers/molecules/Card.tsx
@@ -1,0 +1,46 @@
+import React, { FC, useEffect, useState } from "react";
+import { Timestamp } from "@google-cloud/firestore";
+import { accountFireStore } from "../../firebase/accountFireStore";
+import Card from "../../components/molecules/Card";
+
+type PhotoDataList = {
+  photo_id: string;
+  uid: string;
+  create_time: Timestamp;
+  url: string;
+  latitude: number;
+  longitude: number;
+  photogenic_subject: string;
+};
+
+type Props = {
+  navigation: any;
+  data: PhotoDataList;
+};
+
+const CardContainer: FC<Props> = ({ ...props }) => {
+  const { navigation, data } = props;
+  const [postUserName, setPostUserName] = useState<string>("");
+
+  // ユーザー名の取得
+  const getUserName = (uid: string) => {
+    accountFireStore
+      .getUserName(uid)
+      .then((res: React.SetStateAction<string>) => {
+        setPostUserName(res);
+      })
+      .catch(() => {
+        setPostUserName("名無し");
+      });
+  };
+
+  useEffect(() => {
+    getUserName(data.uid);
+  }, [data]);
+
+  return (
+    <Card navigation={navigation} data={data} postUserName={postUserName} />
+  );
+};
+
+export default CardContainer;


### PR DESCRIPTION
Fix:
前回第二引数にphotoSnapListを格納したuseEffectで、更新のたびにmapで回してユーザー名を取得するやり方を取ったが、この方法だとカードに表示されるユーザー名とカードを飛んだ先のユーザー名が異なる時があると言う問題が発覚した。
- return文のphotoSnapList.map内でgetUserNameを使用していた時は、無限ループの問題はあったものの適切にユーザー名を取得できていた
- カードを飛んだ先では適切なユーザー名が表示されることから、getUserName(data.uid)とすれば確実に求めるユーザー名が取得できる

以上より、内部を別コンポーネントに移せば、適切にユーザー名を取得ができ、かつコンポーネントが別なので無限レンダリングバグも起きないと考えた。
結果、恐らくバグは解消されたものと思われる。