### PR TITLE
Add: 画像投稿時にwidthを600に縮小する処理を追加

### DIFF
--- a/src/containers/molecules/CameraAlbumWrap.tsx
+++ b/src/containers/molecules/CameraAlbumWrap.tsx
@@ -92,12 +92,12 @@ const useAnimation = () => {
 
 const compressImageAsync = (uri: string): Promise<ImageResult> => {
   return new Promise(async (resolve) => {
-    const actions = [];
+    const actions = [{ resize: { width: 600 } }];
     const manipulatorResult = await ImageManipulator.manipulateAsync(
       uri,
       actions,
       {
-        compress: 0.1,
+        compress: 1,
       }
     );
     console.log("manipulate");


### PR DESCRIPTION
Remove
画像を縮小すればかなりサイズが小さくなったので、画像がガビガビになる問題も考慮して圧縮処理を削除した

Add
画像投稿時にwidthを600に縮小し、heightもそれに合わせて自動で小さくなる処理を追加。
3024*4032で7.14MBを圧縮なしで投稿すると、600*800の375.58KBになった